### PR TITLE
버그 수정_ 쿼리DSL 안되는 이유 just 오타,,

### DIFF
--- a/src/main/java/com/ll/gramgram/base/jpa/JpaConfig.java
+++ b/src/main/java/com/ll/gramgram/base/jpa/JpaConfig.java
@@ -17,4 +17,3 @@ public class JpaConfig {
         return new JPAQueryFactory(entityManager);
     }
 }
-  2

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -1,28 +1,28 @@
-//package com.ll.gramgram.boundedContext.likeablePerson.repository;
-//
-//import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
-//import com.querydsl.jpa.impl.JPAQueryFactory;
-//import lombok.RequiredArgsConstructor;
-//
-//import java.util.Optional;
-//import static com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.likeablePerson;
-//
-//@RequiredArgsConstructor
-//public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCustom {
-//    private final JPAQueryFactory jpaQueryFactory;
-//
-//    @Override
-//    public Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername) {
-//        return Optional.ofNullable(
-//                jpaQueryFactory
-//                        .selectFrom(likeablePerson)
-//                        .where(
-//                                likeablePerson.fromInstaMember.id.eq(fromInstaMemberId)
-//                                        .and(
-//                                                likeablePerson.toInstaMember.username.eq(toInstaMemberUsername)
-//                                        )
-//                        )
-//                        .fetchOne()
-//        );
-//    }
-//}
+package com.ll.gramgram.boundedContext.likeablePerson.repository;
+
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+import static com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.likeablePerson;
+
+@RequiredArgsConstructor
+public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(likeablePerson)
+                        .where(
+                                likeablePerson.fromInstaMember.id.eq(fromInstaMemberId)
+                                        .and(
+                                                likeablePerson.toInstaMember.username.eq(toInstaMemberUsername)
+                                        )
+                        )
+                        .fetchOne()
+        );
+    }
+}


### PR DESCRIPTION
## Title: [2Week] 박관희

### 미션 요구사항 분석 & 체크리스트

---

### 체크리스트

---
- [x] 케이스 4 : 한명의 인스타회원이 다른 인스타회원에게 중복으로 호감표시를 할 수 없습니다.
- [x] 케이스 5 : 한명의 인스타회원이 11명 이상의 호감상대를 등록 할 수 없습니다.
- [x] 케이스 6 : 케이스 4 가 발생했을 때 기존의 사유와 다른 사유로 호감을 표시하는 경우에는 성공으로 처리한다.
- [x] 네이버 로그인 구현


### 2주차 미션 요약

---

**[접근 방법]**

#### 케이스4
- 테스트 코드 먼저 작성하고 기술 개발로 넘어가려고 시도.
- 생각만큼 잘 안돼서 기술 개발로 넘어갔다.
- 케이스4에대해 어떤 식으로 해야할지 많이 고민. 케이스4SQL에서 단서 찾았다.
- byAandB() 가 가능하다는 것을 알고 사용.
- 기술 개발하다 테스트 코드에 대한 감이 잡혀서 시도.
- test.html 을 하나 만들고
  중복시 test.html 로 이동. 그래서 그안에 내용이 fail 이면 통과. (더 좋은 방법이 있을것 같음.)
- 해당 테스트 코드 정상 작동 확인.

#### 케이스5
- 역시 테스트 코드 먼저 작성하고 기술 개발로.
- 테스트 코드 작성이 잘 안돼서 일단 기술 개발로.
- 처음에는 숫자를 서비스에 넣어 하드 코딩. 추후 리팩토링.
- 기술 개발후 테스트 코드로 테스트.
- 케이스4와의 테스트 방식 비슷. test.html의 내용 fail 과 같으면 통과.
- 해당 테스트 코드 정상 작동 확인.

#### 케이스6
- 테스트 코드 먼저 작성 시도. (실패하는 코드 작성)
- 처음에는 단순히 선호 유형만 다르면 save() 작동되게 함.
- 코드 작성후 알게된 점이 유형 다르면 통과하지만, 
   같은 아이디 다른 유형이 단순히 추가로 db에 저장되는 것이었다.
- 코드 수정. update 에대해 고민과 서치.
- 레포지토리에 update쿼리 이용해서 메서드 작성.
- 테스트 코드 통과.(잘 만든 테스트 코드가 아니다,,)

#### 코드리팩토링


**[특이사항]**

- historyBack, redirectWithMsg 같은 메서드는 어떻게 테스트 해야하는지 모르겠다.
- 추후 지속적인 코드 리팩토링 필요(변수명, 코드 모듈화등)
- 어떻게 리팩토링 해야할지 아직 막막하다.